### PR TITLE
Add dType.pipe()

### DIFF
--- a/contracts/data/dtypes_composed.json
+++ b/contracts/data/dtypes_composed.json
@@ -40,6 +40,20 @@
         ]
     },
     {
+        "name": "double",
+        "types": [
+            {"name": "TypeA", "label": "data", "relation":0, "dimensions":[]}
+        ],
+        "optionals": [],
+        "lang": 0,
+        "typeChoice": 4,
+        "contractAddress": "0x0000000000000000000000000000000000000000",
+        "source": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "outputs": [
+            {"name": "TypeA", "label": "typeAarr", "relation":0, "dimensions":[]}
+        ]
+    },
+    {
         "name": "doubleBalances",
         "types": [
             {"name": "TypeA", "label": "data", "relation":0, "dimensions":[""]}

--- a/contracts/migrations/2_deploy_contracts.js
+++ b/contracts/migrations/2_deploy_contracts.js
@@ -52,6 +52,9 @@ module.exports = async function(deployer, network, accounts) {
             case 'doubleBalances':
                 dtypesComposed[i].contractAddress = typeAAF.address;
                 break;
+            case 'double':
+                dtypesComposed[i].contractAddress = typeAAF.address;
+                break;
         }
         let tx = await dtypeContract.insert(dtypesComposed[i], {from: accounts[0]});
     }

--- a/contracts/test/dtype_map.js
+++ b/contracts/test/dtype_map.js
@@ -1,14 +1,21 @@
 const dType = artifacts.require('dType.sol');
+const typeALib = artifacts.require('typeALib.sol');
 const typeAContract = artifacts.require('typeAContract.sol');
 const typeAAFunctions = artifacts.require('typeAAFunctions.sol');
 const testUtils = artifacts.require('TestUtils.sol')
 
 
 contract('type HOFs', async (accounts) => {
-    let dtype, typeA, typeAA, typeAAF, testUtilsContract;
+    let dtype, typeA, typeAL, typeAA, typeAAF, testUtilsContract;
+    let tokenAddress = '0xEAd8C52989b587B0c6a8478f8B6dd447E2fc8B1f';
+    let data = [
+        {balance: 10, token: tokenAddress},
+        {balance: 5, token: tokenAddress},
+    ];
 
     it('deploy', async () => {
         dtype = await dType.deployed();
+        typeAL = await typeALib.deployed();
         typeA = await typeAContract.deployed();
         typeAAF = await typeAAFunctions.deployed();
         testUtilsContract = await testUtils.deployed();
@@ -16,11 +23,6 @@ contract('type HOFs', async (accounts) => {
 
     it('run map', async () => {
         let logs, hash, index;
-        let tokenAddress = '0xEAd8C52989b587B0c6a8478f8B6dd447E2fc8B1f';
-        let data = [
-            {balance: 10, token: tokenAddress},
-            {balance: 5, token: tokenAddress},
-        ];
 
         let mapHash = await dtype.getTypeHash(0, 'doubleBalances');
 
@@ -35,5 +37,17 @@ contract('type HOFs', async (accounts) => {
         result.forEach((typeAData, i) => {
             assert.equal(typeAData.balance, data[i].balance * 2, 'Balance not doubled');
         });
+    });
+
+    it('pipe', async() => {
+        let dataHash, funcHash, result;
+        let {logs} = await typeA.insert(data[0]);
+        dataHash = logs[0].args.hash;
+
+        funcHash = await dtype.getTypeHash(0, 'double');
+        result = await dtype.pipeView([dataHash], [funcHash, funcHash, funcHash]);
+        result = await typeAL.structureBytes(result);
+
+        assert.equal(result.balance, data[0].balance * (2 ** 3));
     });
 });


### PR DESCRIPTION

- Add pipe function to `dType`, use `staticcall` instead of `call` for `view` functions
- Add `double` function & test `dType.pipe()`